### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,34 @@
+{
+  "name": "unexpected-sinon",
+  "version": "5.0.0",
+  "authors": [
+    "Sune Simonsen <sune@we-knowhow.dk>"
+  ],
+  "description": "Extends the Unexpected assertion library with integration for the Sinonjs mocking library",
+  "main": "lib/unexpected-sinon.js",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "unexpected",
+    "sinon",
+    "assertion",
+    "extension",
+    "expect",
+    "assert"
+  ],
+  "homepage": "https://github.com/sunesimonsen/unexpected-sinon",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "Makefile"
+  ],
+  "dependencies": {
+    "unexpected": ">5.0.0"
+  }
+}


### PR DESCRIPTION
As discussed on gitter.

I accidentally registered the unexpected-sinon package in bower with the wrong git repository endpoint, so now it needs to be unregistered and re-registered with the correct enpoint. Could you make me a collaborator on this project so I can do that (sadly that is required), or follwo these instructions  to do it yourself? https://github.com/bower/bower/issues/120